### PR TITLE
Add webhook deduplication queue for coalescing duplicate events

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -35,3 +35,22 @@ CREATE TABLE budget_usage (
 CREATE INDEX idx_executions_status ON executions(status);
 CREATE INDEX idx_executions_issue ON executions(issue_id);
 CREATE INDEX idx_nudge_queue_pending ON nudge_queue(processed_at) WHERE processed_at IS NULL;
+
+-- Webhook deduplication queue
+CREATE TABLE webhook_events (
+    id UUID PRIMARY KEY,
+    delivery_id TEXT NOT NULL UNIQUE,  -- X-GitHub-Delivery header (idempotency key)
+    event_type TEXT NOT NULL,          -- issues, issue_comment, etc.
+    action TEXT,                       -- opened, labeled, created, etc.
+    repo TEXT,
+    issue_id TEXT,
+    payload TEXT,                      -- JSON payload for processing
+    processed BOOLEAN NOT NULL DEFAULT FALSE,
+    coalesced_into UUID,               -- Reference to primary event if deduplicated
+    received_at TIMESTAMPTZ DEFAULT NOW(),
+    processed_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX idx_webhook_events_delivery_id ON webhook_events(delivery_id);
+CREATE INDEX idx_webhook_events_unprocessed ON webhook_events(processed, received_at) WHERE processed = FALSE;
+CREATE INDEX idx_webhook_events_issue ON webhook_events(repo, issue_id, received_at);

--- a/src/agent_grid/config.py
+++ b/src/agent_grid/config.py
@@ -57,6 +57,10 @@ class Settings(BaseSettings):
     # coordinator: Publishes jobs to SQS, listens for results (cloud)
     # worker: Polls SQS for jobs, runs agents locally (desktop)
 
+    # Webhook deduplication settings
+    webhook_dedup_quiet_period_seconds: int = 5  # Wait time before processing (allows related events to arrive)
+    webhook_dedup_poll_interval_seconds: int = 2  # How often to check for events to process
+
     model_config = {"env_prefix": "AGENT_GRID_", "env_file": ".env", "extra": "ignore"}
 
 

--- a/src/agent_grid/coordinator/__init__.py
+++ b/src/agent_grid/coordinator/__init__.py
@@ -4,6 +4,7 @@ from .public_api import (
     # Models
     NudgeRequest,
     NudgeRequestCreate,
+    WebhookEvent,
     utc_now,
     # Router
     coordinator_router,
@@ -14,11 +15,13 @@ from .budget_manager import BudgetManager, get_budget_manager
 from .management_loop import ManagementLoop, get_management_loop
 from .database import Database, get_database
 from .chat_logger import AgentEventLogger, get_agent_event_logger
+from .webhook_processor import WebhookProcessor, get_webhook_processor
 
 __all__ = [
     # Public API - Models
     "NudgeRequest",
     "NudgeRequestCreate",
+    "WebhookEvent",
     "utc_now",
     # Public API - Router
     "coordinator_router",
@@ -35,4 +38,6 @@ __all__ = [
     "get_database",
     "AgentEventLogger",
     "get_agent_event_logger",
+    "WebhookProcessor",
+    "get_webhook_processor",
 ]

--- a/src/agent_grid/coordinator/public_api.py
+++ b/src/agent_grid/coordinator/public_api.py
@@ -39,6 +39,22 @@ class NudgeRequest(BaseModel):
     processed_at: datetime | None = None
 
 
+class WebhookEvent(BaseModel):
+    """A GitHub webhook event stored for deduplication processing."""
+
+    id: UUID
+    delivery_id: str  # X-GitHub-Delivery header (idempotency key)
+    event_type: str  # issues, issue_comment, etc.
+    action: str | None = None  # opened, labeled, created, etc.
+    repo: str | None = None
+    issue_id: str | None = None
+    payload: str | None = None  # JSON payload for processing
+    processed: bool = False
+    coalesced_into: UUID | None = None  # Reference to primary event if deduplicated
+    received_at: datetime = Field(default_factory=utc_now)
+    processed_at: datetime | None = None
+
+
 class NudgeRequestCreate(BaseModel):
     """Request to create a nudge."""
 

--- a/src/agent_grid/coordinator/webhook_processor.py
+++ b/src/agent_grid/coordinator/webhook_processor.py
@@ -1,0 +1,343 @@
+"""Background webhook processor with deduplication and coalescing.
+
+This module implements a two-stage webhook processing architecture:
+1. Webhook Ingestion: Events are immediately stored in the database
+2. Webhook Processing: Background processor reads events after a quiet period,
+   deduplicates by issue ID, and decides whether to launch agents
+"""
+
+import asyncio
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from ..config import settings
+from ..execution_grid import event_bus, EventType
+from .database import get_database
+from .public_api import WebhookEvent, utc_now
+
+logger = logging.getLogger("agent_grid.webhook_processor")
+
+
+class WebhookProcessor:
+    """
+    Background processor for webhook events.
+
+    Implements:
+    - Time-based debouncing per issue (waits for quiet period before processing)
+    - Event coalescing (combines multiple events for same issue)
+    - Smart decision making (e.g., don't launch if issue opened then immediately closed)
+    """
+
+    def __init__(
+        self,
+        quiet_period_seconds: int | None = None,
+        poll_interval_seconds: int | None = None,
+    ):
+        """
+        Initialize the webhook processor.
+
+        Args:
+            quiet_period_seconds: Time to wait after receiving an event before processing.
+                                  Allows related events to arrive. Default from settings.
+            poll_interval_seconds: How often to check for events to process.
+                                   Default from settings.
+        """
+        self._db = get_database()
+        self._quiet_period = timedelta(
+            seconds=quiet_period_seconds or settings.webhook_dedup_quiet_period_seconds
+        )
+        self._poll_interval = poll_interval_seconds or settings.webhook_dedup_poll_interval_seconds
+        self._running = False
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Start the background processing loop."""
+        if self._running:
+            return
+
+        self._running = True
+        self._task = asyncio.create_task(self._process_loop())
+        logger.info(
+            f"Webhook processor started (quiet_period={self._quiet_period.total_seconds()}s, "
+            f"poll_interval={self._poll_interval}s)"
+        )
+
+    async def stop(self) -> None:
+        """Stop the background processing loop."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Webhook processor stopped")
+
+    async def _process_loop(self) -> None:
+        """Main processing loop."""
+        while self._running:
+            try:
+                await self._process_batch()
+            except Exception as e:
+                logger.error(f"Error in webhook processor loop: {e}", exc_info=True)
+
+            await asyncio.sleep(self._poll_interval)
+
+    async def _process_batch(self) -> None:
+        """Process a batch of webhook events."""
+        # Get events that have been waiting longer than the quiet period
+        cutoff_time = utc_now() - self._quiet_period
+        events = await self._db.get_unprocessed_webhook_events(
+            older_than=cutoff_time,
+            limit=100,
+        )
+
+        if not events:
+            return
+
+        logger.debug(f"Processing {len(events)} webhook events")
+
+        # Group events by (repo, issue_id) for coalescing
+        events_by_issue: dict[tuple[str | None, str | None], list[WebhookEvent]] = defaultdict(list)
+        for event in events:
+            key = (event.repo, event.issue_id)
+            events_by_issue[key].append(event)
+
+        # Process each issue's events
+        for (repo, issue_id), issue_events in events_by_issue.items():
+            await self._process_issue_events(repo, issue_id, issue_events)
+
+    async def _process_issue_events(
+        self,
+        repo: str | None,
+        issue_id: str | None,
+        events: list[WebhookEvent],
+    ) -> None:
+        """
+        Process all events for a single issue.
+
+        This method coalesces multiple events and makes a single decision
+        about whether to trigger an agent.
+        """
+        if not events:
+            return
+
+        # Sort by received_at to process in order
+        events = sorted(events, key=lambda e: e.received_at)
+
+        # The primary event is the first one - others will be coalesced into it
+        primary_event = events[0]
+
+        # Analyze the event sequence to make a decision
+        decision = self._analyze_event_sequence(events)
+
+        if decision.should_trigger:
+            # Publish the appropriate event to the event bus
+            await self._publish_coalesced_event(primary_event, decision, events)
+        else:
+            logger.info(
+                f"Skipping events for {repo}#{issue_id}: {decision.reason} "
+                f"(coalesced {len(events)} events)"
+            )
+
+        # Mark all events as processed
+        event_ids = [e.id for e in events]
+        coalesced_into = primary_event.id if len(events) > 1 else None
+        await self._db.mark_webhook_events_processed(event_ids, coalesced_into)
+
+    def _analyze_event_sequence(self, events: list[WebhookEvent]) -> "ProcessingDecision":
+        """
+        Analyze a sequence of events to decide what action to take.
+
+        Examples:
+        - Issue opened → trigger
+        - Issue opened, then labeled → trigger (with labels)
+        - Issue opened, then closed → don't trigger
+        - Issue labeled with trigger label → trigger
+        - Issue unlabeled (removed trigger label) → don't trigger
+        - Nudge request → trigger
+        """
+        if not events:
+            return ProcessingDecision(should_trigger=False, reason="no events")
+
+        # Track the final state
+        actions = [e.action for e in events]
+        event_types = [e.event_type for e in events]
+
+        # Check for issue closed event - if present, don't launch
+        if "closed" in actions:
+            return ProcessingDecision(
+                should_trigger=False,
+                reason="issue was closed",
+            )
+
+        # Check for issue_comment with nudge
+        for event in events:
+            if event.event_type == "issue_comment" and event.action == "created":
+                if event.payload:
+                    try:
+                        payload = json.loads(event.payload)
+                        comment_body = payload.get("comment", {}).get("body", "")
+                        if "@agent-grid nudge" in comment_body.lower():
+                            return ProcessingDecision(
+                                should_trigger=True,
+                                event_type=EventType.NUDGE_REQUESTED,
+                                reason="nudge command in comment",
+                            )
+                    except json.JSONDecodeError:
+                        pass
+
+        # Check for issue events
+        has_opened = "opened" in actions
+        has_labeled = "labeled" in actions
+
+        # Collect all labels from the most recent event that has them
+        final_labels: list[str] = []
+        for event in reversed(events):
+            if event.payload:
+                try:
+                    payload = json.loads(event.payload)
+                    if "labels" in payload:
+                        final_labels = payload.get("labels", [])
+                        break
+                    # Also check nested in issue object
+                    issue_data = payload.get("issue", {})
+                    if issue_data and "labels" in issue_data:
+                        final_labels = [
+                            label["name"] if isinstance(label, dict) else label
+                            for label in issue_data.get("labels", [])
+                        ]
+                        break
+                except json.JSONDecodeError:
+                    pass
+
+        # Determine trigger labels
+        trigger_labels = {"agent", "automated", "agent-grid"}
+        has_trigger_label = bool(set(final_labels) & trigger_labels)
+
+        if has_opened and has_trigger_label:
+            return ProcessingDecision(
+                should_trigger=True,
+                event_type=EventType.ISSUE_CREATED,
+                reason="issue opened with trigger label",
+                labels=final_labels,
+            )
+
+        if has_opened:
+            # Opened without trigger label - check if label was added
+            if has_trigger_label:
+                return ProcessingDecision(
+                    should_trigger=True,
+                    event_type=EventType.ISSUE_CREATED,
+                    reason="issue opened and labeled",
+                    labels=final_labels,
+                )
+            # No trigger label
+            return ProcessingDecision(
+                should_trigger=False,
+                reason="issue opened without trigger label",
+            )
+
+        if has_labeled and has_trigger_label:
+            return ProcessingDecision(
+                should_trigger=True,
+                event_type=EventType.ISSUE_UPDATED,
+                reason="trigger label added",
+                labels=final_labels,
+            )
+
+        # Default: don't trigger
+        return ProcessingDecision(
+            should_trigger=False,
+            reason=f"no actionable events (actions: {actions})",
+        )
+
+    async def _publish_coalesced_event(
+        self,
+        primary_event: WebhookEvent,
+        decision: "ProcessingDecision",
+        events: list[WebhookEvent],
+    ) -> None:
+        """Publish a coalesced event to the event bus."""
+        # Get the most recent payload for full context
+        payload_data: dict[str, Any] = {}
+        for event in reversed(events):
+            if event.payload:
+                try:
+                    payload_data = json.loads(event.payload)
+                    break
+                except json.JSONDecodeError:
+                    pass
+
+        # Build the event payload
+        event_payload: dict[str, Any] = {
+            "repo": primary_event.repo,
+            "issue_id": primary_event.issue_id,
+            "coalesced_events": len(events),
+            "processing_reason": decision.reason,
+        }
+
+        # Add type-specific fields
+        if decision.event_type == EventType.ISSUE_CREATED:
+            issue_data = payload_data.get("issue", payload_data)
+            event_payload.update({
+                "title": issue_data.get("title"),
+                "body": issue_data.get("body"),
+                "labels": decision.labels or [],
+                "html_url": issue_data.get("html_url"),
+            })
+        elif decision.event_type == EventType.ISSUE_UPDATED:
+            issue_data = payload_data.get("issue", payload_data)
+            event_payload.update({
+                "action": "labeled",  # Coalesced action
+                "title": issue_data.get("title"),
+                "body": issue_data.get("body"),
+                "state": issue_data.get("state"),
+                "labels": decision.labels or [],
+            })
+        elif decision.event_type == EventType.NUDGE_REQUESTED:
+            comment_data = payload_data.get("comment", {})
+            event_payload.update({
+                "source": "comment",
+                "comment_body": comment_data.get("body", ""),
+            })
+
+        logger.info(
+            f"Publishing {decision.event_type} for {primary_event.repo}#{primary_event.issue_id} "
+            f"(coalesced {len(events)} events, reason: {decision.reason})"
+        )
+
+        await event_bus.publish(decision.event_type, event_payload)
+
+
+class ProcessingDecision:
+    """Result of analyzing a sequence of webhook events."""
+
+    def __init__(
+        self,
+        should_trigger: bool,
+        event_type: EventType | None = None,
+        reason: str = "",
+        labels: list[str] | None = None,
+    ):
+        self.should_trigger = should_trigger
+        self.event_type = event_type
+        self.reason = reason
+        self.labels = labels
+
+
+# Global instance
+_webhook_processor: WebhookProcessor | None = None
+
+
+def get_webhook_processor() -> WebhookProcessor:
+    """Get the global webhook processor instance."""
+    global _webhook_processor
+    if _webhook_processor is None:
+        _webhook_processor = WebhookProcessor()
+    return _webhook_processor

--- a/src/agent_grid/issue_tracker/webhook_handler.py
+++ b/src/agent_grid/issue_tracker/webhook_handler.py
@@ -1,13 +1,26 @@
-"""GitHub webhook processing."""
+"""GitHub webhook processing with deduplication support.
+
+Webhooks are stored in a queue for background processing rather than
+being published directly to the event bus. This allows for:
+- Deduplication of duplicate webhook deliveries (using X-GitHub-Delivery)
+- Coalescing multiple events for the same issue (e.g., opened + labeled)
+- Smart decision making (e.g., don't launch if opened then closed)
+"""
 
 import hashlib
 import hmac
+import json
+import logging
 from typing import Any
+from uuid import uuid4
 
 from fastapi import APIRouter, Header, HTTPException, Request
 
-from ..execution_grid import event_bus, EventType
 from ..config import settings
+from ..coordinator.database import get_database
+from ..coordinator.public_api import WebhookEvent, utc_now
+
+logger = logging.getLogger("agent_grid.webhook_handler")
 
 webhook_router = APIRouter(prefix="/webhooks", tags=["webhooks"])
 
@@ -34,11 +47,19 @@ async def handle_github_webhook(
     request: Request,
     x_github_event: str = Header(..., alias="X-GitHub-Event"),
     x_hub_signature_256: str | None = Header(None, alias="X-Hub-Signature-256"),
+    x_github_delivery: str | None = Header(None, alias="X-GitHub-Delivery"),
 ) -> dict[str, Any]:
     """
     Handle incoming GitHub webhooks.
 
-    Processes issue events and publishes them to the event bus.
+    Instead of processing events immediately, this stores them in a queue
+    for background processing. The background processor will:
+    - Deduplicate events by delivery ID
+    - Coalesce multiple events for the same issue
+    - Make smart decisions about when to launch agents
+
+    The X-GitHub-Delivery header is used as an idempotency key to prevent
+    duplicate processing if GitHub retries webhook delivery.
     """
     payload = await request.body()
 
@@ -47,77 +68,53 @@ async def handle_github_webhook(
         if not verify_signature(payload, x_hub_signature_256, settings.github_webhook_secret):
             raise HTTPException(status_code=401, detail="Invalid signature")
 
-    data = await request.json()
-
-    # Handle different event types
-    if x_github_event == "issues":
-        await _handle_issue_event(data)
-    elif x_github_event == "issue_comment":
-        await _handle_issue_comment_event(data)
-    elif x_github_event == "ping":
+    # Handle ping immediately (no need to queue)
+    if x_github_event == "ping":
         return {"status": "pong"}
 
-    return {"status": "ok"}
+    data = await request.json()
 
+    # Generate delivery ID if not provided (for testing)
+    delivery_id = x_github_delivery or str(uuid4())
 
-async def _handle_issue_event(data: dict[str, Any]) -> None:
-    """Handle issue opened/edited/closed events."""
+    # Extract common fields
     action = data.get("action")
-    issue = data.get("issue", {})
     repo = data.get("repository", {})
-
     repo_full_name = repo.get("full_name", "")
-    issue_number = issue.get("number")
 
-    if action == "opened":
-        await event_bus.publish(
-            EventType.ISSUE_CREATED,
-            {
-                "repo": repo_full_name,
-                "issue_id": str(issue_number),
-                "title": issue.get("title"),
-                "body": issue.get("body"),
-                "labels": [label["name"] for label in issue.get("labels", [])],
-                "html_url": issue.get("html_url"),
-            },
+    # Get issue ID based on event type
+    issue_id: str | None = None
+    if x_github_event == "issues":
+        issue = data.get("issue", {})
+        issue_id = str(issue.get("number")) if issue.get("number") else None
+    elif x_github_event == "issue_comment":
+        issue = data.get("issue", {})
+        issue_id = str(issue.get("number")) if issue.get("number") else None
+
+    # Store in webhook queue for background processing
+    webhook_event = WebhookEvent(
+        id=uuid4(),
+        delivery_id=delivery_id,
+        event_type=x_github_event,
+        action=action,
+        repo=repo_full_name or None,
+        issue_id=issue_id,
+        payload=json.dumps(data),
+        processed=False,
+        received_at=utc_now(),
+    )
+
+    db = get_database()
+    inserted = await db.create_webhook_event(webhook_event)
+
+    if inserted:
+        logger.info(
+            f"Queued webhook event: delivery_id={delivery_id}, "
+            f"type={x_github_event}, action={action}, "
+            f"repo={repo_full_name}, issue={issue_id}"
         )
-    elif action in ("edited", "labeled", "unlabeled", "assigned", "closed", "reopened"):
-        await event_bus.publish(
-            EventType.ISSUE_UPDATED,
-            {
-                "repo": repo_full_name,
-                "issue_id": str(issue_number),
-                "action": action,
-                "title": issue.get("title"),
-                "body": issue.get("body"),
-                "state": issue.get("state"),
-                "labels": [label["name"] for label in issue.get("labels", [])],
-            },
-        )
-
-
-async def _handle_issue_comment_event(data: dict[str, Any]) -> None:
-    """Handle issue comment events."""
-    action = data.get("action")
-    issue = data.get("issue", {})
-    comment = data.get("comment", {})
-    repo = data.get("repository", {})
-
-    if action != "created":
-        return
-
-    repo_full_name = repo.get("full_name", "")
-    issue_number = issue.get("number")
-    comment_body = comment.get("body", "")
-
-    # Check for nudge commands in comments
-    if "@agent-grid nudge" in comment_body.lower():
-        await event_bus.publish(
-            EventType.NUDGE_REQUESTED,
-            {
-                "repo": repo_full_name,
-                "issue_id": str(issue_number),
-                "source": "comment",
-                "comment_body": comment_body,
-            },
-        )
+        return {"status": "queued", "delivery_id": delivery_id}
+    else:
+        # Duplicate delivery - idempotent response
+        logger.debug(f"Duplicate webhook ignored: delivery_id={delivery_id}")
+        return {"status": "duplicate", "delivery_id": delivery_id}

--- a/src/agent_grid/migrations/versions/20260128_000001_add_webhook_events.py
+++ b/src/agent_grid/migrations/versions/20260128_000001_add_webhook_events.py
@@ -1,0 +1,71 @@
+"""Add webhook_events table for deduplication queue.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-01-28 00:00:01.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create webhook_events table for deduplication
+    op.create_table(
+        "webhook_events",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("delivery_id", sa.Text(), nullable=False),  # X-GitHub-Delivery header
+        sa.Column("event_type", sa.Text(), nullable=False),  # issues, issue_comment, etc.
+        sa.Column("action", sa.Text(), nullable=True),  # opened, labeled, created, etc.
+        sa.Column("repo", sa.Text(), nullable=True),
+        sa.Column("issue_id", sa.Text(), nullable=True),
+        sa.Column("payload", sa.Text(), nullable=True),  # JSON payload for processing
+        sa.Column("processed", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("coalesced_into", sa.UUID(), nullable=True),  # Reference to primary event if deduplicated
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Index for checking duplicate delivery IDs (idempotency)
+    op.create_index(
+        "idx_webhook_events_delivery_id",
+        "webhook_events",
+        ["delivery_id"],
+        unique=True,
+    )
+
+    # Index for finding unprocessed events
+    op.create_index(
+        "idx_webhook_events_unprocessed",
+        "webhook_events",
+        ["processed", "received_at"],
+        postgresql_where=sa.text("processed = false"),
+    )
+
+    # Index for finding events by issue for coalescing
+    op.create_index(
+        "idx_webhook_events_issue",
+        "webhook_events",
+        ["repo", "issue_id", "received_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_webhook_events_issue", table_name="webhook_events")
+    op.drop_index("idx_webhook_events_unprocessed", table_name="webhook_events")
+    op.drop_index("idx_webhook_events_delivery_id", table_name="webhook_events")
+    op.drop_table("webhook_events")

--- a/tests/test_webhook_processor.py
+++ b/tests/test_webhook_processor.py
@@ -1,0 +1,246 @@
+"""Tests for webhook deduplication processor."""
+
+import json
+import pytest
+from datetime import timedelta
+from uuid import uuid4
+
+from agent_grid.coordinator.public_api import WebhookEvent, utc_now
+from agent_grid.coordinator.webhook_processor import WebhookProcessor, ProcessingDecision
+from agent_grid.execution_grid import EventType
+
+
+class TestProcessingDecision:
+    """Tests for ProcessingDecision model."""
+
+    def test_should_trigger_false(self):
+        """Test decision with no trigger."""
+        decision = ProcessingDecision(should_trigger=False, reason="no events")
+        assert decision.should_trigger is False
+        assert decision.event_type is None
+
+    def test_should_trigger_true(self):
+        """Test decision with trigger."""
+        decision = ProcessingDecision(
+            should_trigger=True,
+            event_type=EventType.ISSUE_CREATED,
+            reason="issue opened with trigger label",
+            labels=["agent"],
+        )
+        assert decision.should_trigger is True
+        assert decision.event_type == EventType.ISSUE_CREATED
+        assert "agent" in decision.labels
+
+
+class TestWebhookProcessorAnalysis:
+    """Tests for WebhookProcessor event analysis logic."""
+
+    def create_event(
+        self,
+        event_type: str = "issues",
+        action: str = "opened",
+        labels: list[str] | None = None,
+        include_issue_data: bool = True,
+    ) -> WebhookEvent:
+        """Helper to create test webhook events."""
+        payload = {"action": action}
+        if include_issue_data:
+            payload["issue"] = {
+                "number": 123,
+                "title": "Test Issue",
+                "body": "Test body",
+                "state": "open",
+                "labels": [{"name": label} for label in (labels or [])],
+            }
+        return WebhookEvent(
+            id=uuid4(),
+            delivery_id=str(uuid4()),
+            event_type=event_type,
+            action=action,
+            repo="owner/repo",
+            issue_id="123",
+            payload=json.dumps(payload),
+            received_at=utc_now(),
+        )
+
+    def test_issue_opened_with_trigger_label(self):
+        """Test: issue opened with agent label → should trigger."""
+        processor = WebhookProcessor()
+        events = [self.create_event(action="opened", labels=["agent"])]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is True
+        assert decision.event_type == EventType.ISSUE_CREATED
+        assert "agent" in decision.labels
+
+    def test_issue_opened_without_trigger_label(self):
+        """Test: issue opened without trigger label → should not trigger."""
+        processor = WebhookProcessor()
+        events = [self.create_event(action="opened", labels=["bug"])]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is False
+        assert "without trigger label" in decision.reason
+
+    def test_issue_opened_then_labeled(self):
+        """Test: issue opened, then labeled with agent → should trigger."""
+        processor = WebhookProcessor()
+        events = [
+            self.create_event(action="opened", labels=[]),
+            self.create_event(action="labeled", labels=["agent"]),
+        ]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is True
+        assert decision.event_type == EventType.ISSUE_CREATED
+
+    def test_issue_opened_then_closed(self):
+        """Test: issue opened, then closed → should NOT trigger."""
+        processor = WebhookProcessor()
+        events = [
+            self.create_event(action="opened", labels=["agent"]),
+            self.create_event(action="closed", labels=["agent"]),
+        ]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is False
+        assert "closed" in decision.reason
+
+    def test_issue_labeled_with_trigger(self):
+        """Test: existing issue gets trigger label → should trigger."""
+        processor = WebhookProcessor()
+        events = [self.create_event(action="labeled", labels=["agent"])]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is True
+        assert decision.event_type == EventType.ISSUE_UPDATED
+
+    def test_nudge_in_comment(self):
+        """Test: comment with nudge command → should trigger."""
+        processor = WebhookProcessor()
+        payload = {
+            "action": "created",
+            "issue": {"number": 123},
+            "comment": {"body": "Please @agent-grid nudge this issue"},
+        }
+        events = [
+            WebhookEvent(
+                id=uuid4(),
+                delivery_id=str(uuid4()),
+                event_type="issue_comment",
+                action="created",
+                repo="owner/repo",
+                issue_id="123",
+                payload=json.dumps(payload),
+                received_at=utc_now(),
+            )
+        ]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is True
+        assert decision.event_type == EventType.NUDGE_REQUESTED
+
+    def test_empty_events(self):
+        """Test: no events → should not trigger."""
+        processor = WebhookProcessor()
+        decision = processor._analyze_event_sequence([])
+
+        assert decision.should_trigger is False
+        assert decision.reason == "no events"
+
+    def test_coalesced_events_opened_multiple_labeled(self):
+        """Test: opened + multiple label events → single trigger with final labels."""
+        processor = WebhookProcessor()
+        events = [
+            self.create_event(action="opened", labels=[]),
+            self.create_event(action="labeled", labels=["bug"]),
+            self.create_event(action="labeled", labels=["bug", "agent"]),
+        ]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is True
+        assert decision.event_type == EventType.ISSUE_CREATED
+        assert "agent" in decision.labels
+        assert "bug" in decision.labels
+
+    def test_automated_label_triggers(self):
+        """Test: 'automated' label also triggers."""
+        processor = WebhookProcessor()
+        events = [self.create_event(action="opened", labels=["automated"])]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is True
+
+    def test_agent_grid_label_triggers(self):
+        """Test: 'agent-grid' label also triggers."""
+        processor = WebhookProcessor()
+        events = [self.create_event(action="opened", labels=["agent-grid"])]
+
+        decision = processor._analyze_event_sequence(events)
+
+        assert decision.should_trigger is True
+
+
+class TestWebhookEventModel:
+    """Tests for WebhookEvent model."""
+
+    def test_create_webhook_event(self):
+        """Test creating a webhook event."""
+        event = WebhookEvent(
+            id=uuid4(),
+            delivery_id="abc-123",
+            event_type="issues",
+            action="opened",
+            repo="owner/repo",
+            issue_id="42",
+            payload='{"test": true}',
+        )
+        assert event.delivery_id == "abc-123"
+        assert event.event_type == "issues"
+        assert event.processed is False
+        assert event.coalesced_into is None
+
+    def test_webhook_event_defaults(self):
+        """Test webhook event default values."""
+        event = WebhookEvent(
+            id=uuid4(),
+            delivery_id="xyz-456",
+            event_type="ping",
+        )
+        assert event.action is None
+        assert event.repo is None
+        assert event.issue_id is None
+        assert event.payload is None
+        assert event.processed is False
+
+
+class TestWebhookProcessorConfig:
+    """Tests for WebhookProcessor configuration."""
+
+    def test_custom_quiet_period(self):
+        """Test custom quiet period configuration."""
+        processor = WebhookProcessor(quiet_period_seconds=10)
+        assert processor._quiet_period == timedelta(seconds=10)
+
+    def test_custom_poll_interval(self):
+        """Test custom poll interval configuration."""
+        processor = WebhookProcessor(poll_interval_seconds=5)
+        assert processor._poll_interval == 5
+
+    def test_default_config_from_settings(self):
+        """Test default configuration from settings."""
+        from agent_grid.config import settings
+
+        processor = WebhookProcessor()
+        assert processor._quiet_period == timedelta(
+            seconds=settings.webhook_dedup_quiet_period_seconds
+        )
+        assert processor._poll_interval == settings.webhook_dedup_poll_interval_seconds


### PR DESCRIPTION
When GitHub issues are created with labels, GitHub sends multiple webhook events (e.g., issues.opened and issues.labeled). This change implements a two-stage webhook processing architecture to prevent duplicate agent runs:

1. Webhook Ingestion: Events are immediately stored in a database queue using the X-GitHub-Delivery header as an idempotency key

2. Webhook Processor: A background process that:
   - Waits for a configurable "quiet period" (default 5s) before processing
   - Groups events by issue ID and coalesces them
   - Makes smart decisions (e.g., don't launch if issue opened then closed)
   - Publishes a single event to the event bus

Key components:
- WebhookEvent model and database table for storing queued events
- WebhookProcessor background service with event analysis logic
- Updated webhook handler to queue events instead of direct publishing
- New config options: webhook_dedup_quiet_period_seconds, webhook_dedup_poll_interval_seconds