### PR TITLE
Make agent executions less hard coded

### DIFF
--- a/src/agent_grid/coordinator/database.py
+++ b/src/agent_grid/coordinator/database.py
@@ -44,8 +44,13 @@ class Database:
 
     # Execution operations
 
-    async def create_execution(self, execution: AgentExecution) -> None:
-        """Insert a new execution record."""
+    async def create_execution(self, execution: AgentExecution, issue_id: str) -> None:
+        """Insert a new execution record.
+
+        Args:
+            execution: The execution record.
+            issue_id: The issue ID (coordinator's internal tracking).
+        """
         pool = await self._get_pool()
         await pool.execute(
             """
@@ -53,7 +58,7 @@ class Database:
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             """,
             execution.id,
-            execution.issue_id,
+            issue_id,
             execution.repo_url,
             execution.status.value,
             execution.prompt,
@@ -145,7 +150,6 @@ class Database:
         """Convert a database row to an AgentExecution."""
         return AgentExecution(
             id=row["id"],
-            issue_id=row["issue_id"],
             repo_url=row["repo_url"],
             status=ExecutionStatus(row["status"]),
             prompt=row["prompt"],

--- a/src/agent_grid/execution_grid/__init__.py
+++ b/src/agent_grid/execution_grid/__init__.py
@@ -5,6 +5,7 @@ from .public_api import (
     AgentExecution,
     Event,
     EventType,
+    ExecutionConfig,
     ExecutionStatus,
     utc_now,
     # Type aliases
@@ -22,6 +23,7 @@ __all__ = [
     "AgentExecution",
     "Event",
     "EventType",
+    "ExecutionConfig",
     "ExecutionStatus",
     "utc_now",
     # Public API - Type aliases

--- a/src/agent_grid/execution_grid/event_publisher.py
+++ b/src/agent_grid/execution_grid/event_publisher.py
@@ -12,7 +12,6 @@ class ExecutionEventPublisher:
     async def agent_started(
         self,
         execution_id: UUID,
-        issue_id: str,
         repo_url: str,
     ) -> None:
         """Publish agent started event."""
@@ -20,7 +19,6 @@ class ExecutionEventPublisher:
             EventType.AGENT_STARTED,
             {
                 "execution_id": str(execution_id),
-                "issue_id": issue_id,
                 "repo_url": repo_url,
             },
         )

--- a/src/agent_grid/execution_grid/public_api.py
+++ b/src/agent_grid/execution_grid/public_api.py
@@ -26,6 +26,14 @@ def utc_now() -> datetime:
 # Models
 # =============================================================================
 
+class ExecutionConfig(BaseModel):
+    """Configuration for a generic agent execution."""
+
+    repo_url: str  # URL of repository to clone
+    prompt: str  # Full instructions for the agent
+    permission_mode: str = "bypassPermissions"  # ClaudeCodeOptions.permission_mode
+
+
 class ExecutionStatus(str, Enum):
     """Status of an agent execution."""
 
@@ -60,7 +68,6 @@ class AgentExecution(BaseModel):
     """Represents an agent execution."""
 
     id: UUID
-    issue_id: str
     repo_url: str
     status: ExecutionStatus = ExecutionStatus.PENDING
     prompt: str | None = None
@@ -86,19 +93,12 @@ class ExecutionGrid(ABC):
     """Abstract interface for the execution grid service."""
 
     @abstractmethod
-    async def launch_agent(
-        self,
-        issue_id: str,
-        repo_url: str,
-        prompt: str,
-    ) -> UUID:
+    async def launch_agent(self, config: ExecutionConfig) -> UUID:
         """
-        Launch a coding agent for an issue.
+        Launch a generic Claude Code session.
 
         Args:
-            issue_id: The issue ID this agent is working on.
-            repo_url: URL of the repository to clone.
-            prompt: Instructions for the agent.
+            config: Configuration for the execution (repo_url, prompt, permission_mode).
 
         Returns:
             Execution ID for tracking.

--- a/src/agent_grid/execution_grid/repo_manager.py
+++ b/src/agent_grid/execution_grid/repo_manager.py
@@ -65,57 +65,6 @@ class RepoManager:
 
         return work_dir
 
-    async def create_branch(
-        self,
-        execution_id: UUID,
-        branch_name: str,
-    ) -> None:
-        """
-        Create and checkout a new branch for the agent's work.
-
-        Args:
-            execution_id: Execution ID.
-            branch_name: Name of the branch to create.
-        """
-        work_dir = self.get_execution_path(execution_id)
-
-        # Create and checkout branch
-        process = await asyncio.create_subprocess_exec(
-            "git", "checkout", "-b", branch_name,
-            cwd=work_dir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await process.communicate()
-
-        if process.returncode != 0:
-            raise RuntimeError(f"Failed to create branch: {stderr.decode()}")
-
-    async def push_branch(
-        self,
-        execution_id: UUID,
-        branch_name: str,
-    ) -> None:
-        """
-        Push the agent's branch to the remote.
-
-        Args:
-            execution_id: Execution ID.
-            branch_name: Name of the branch to push.
-        """
-        work_dir = self.get_execution_path(execution_id)
-
-        process = await asyncio.create_subprocess_exec(
-            "git", "push", "-u", "origin", branch_name,
-            cwd=work_dir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await process.communicate()
-
-        if process.returncode != 0:
-            raise RuntimeError(f"Failed to push branch: {stderr.decode()}")
-
     async def cleanup(self, execution_id: UUID) -> None:
         """
         Clean up the working directory for an execution.

--- a/src/agent_grid/execution_grid/service.py
+++ b/src/agent_grid/execution_grid/service.py
@@ -7,6 +7,7 @@ from .public_api import (
     AgentExecution,
     AgentEventHandler,
     Event,
+    ExecutionConfig,
     ExecutionGrid,
 )
 from .event_bus import event_bus
@@ -29,21 +30,15 @@ class ExecutionGridService(ExecutionGrid):
         # Map handler IDs to internal event handlers for cleanup
         self._handler_mapping: dict[int, Callable[[Event], Awaitable[None]]] = {}
 
-    async def launch_agent(
-        self,
-        issue_id: str,
-        repo_url: str,
-        prompt: str,
-    ) -> UUID:
-        """Launch a coding agent for an issue."""
+    async def launch_agent(self, config: ExecutionConfig) -> UUID:
+        """Launch a generic Claude Code session."""
         execution_id = uuid4()
         execution = AgentExecution(
             id=execution_id,
-            issue_id=issue_id,
-            repo_url=repo_url,
-            prompt=prompt,
+            repo_url=config.repo_url,
+            prompt=config.prompt,
         )
-        self._agent_runner.start_execution(execution, prompt)
+        self._agent_runner.start_execution(execution, config)
         return execution_id
 
     async def get_execution_status(self, execution_id: UUID) -> AgentExecution | None:

--- a/src/agent_grid/execution_grid/sqs_client.py
+++ b/src/agent_grid/execution_grid/sqs_client.py
@@ -20,9 +20,9 @@ class JobRequest(BaseModel):
     """Job request message sent to SQS."""
 
     execution_id: str
-    issue_id: str
     repo_url: str
     prompt: str
+    permission_mode: str = "bypassPermissions"
     created_at: datetime
 
 
@@ -90,10 +90,6 @@ class SQSClient:
                     "execution_id": {
                         "DataType": "String",
                         "StringValue": request.execution_id,
-                    },
-                    "issue_id": {
-                        "DataType": "String",
-                        "StringValue": request.issue_id,
                     },
                 },
             )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -78,7 +78,8 @@ class TestScheduler:
         from agent_grid.coordinator.scheduler import Scheduler
 
         scheduler = Scheduler()
-        prompt = scheduler._generate_prompt("Fix bug", "The app crashes on startup", "42")
+        prompt = scheduler._generate_prompt("Fix bug", "The app crashes on startup", "42", "owner/repo")
         assert "Fix bug" in prompt
         assert "crashes on startup" in prompt
         assert "#42" in prompt
+        assert "agent/42" in prompt  # Branch name should be included

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -176,32 +176,25 @@ class TestEndToEnd:
 
             repo_manager.clone_repo = mock_clone
 
-            # Patch create_branch to be a no-op
-            async def mock_create_branch(execution_id, branch_name):
-                pass
-
-            repo_manager.create_branch = mock_create_branch
-
-            # Patch the push to be a no-op
-            async def mock_push(execution_id, branch_name):
-                pass
-
-            repo_manager.push_branch = mock_push
-
-            # Create execution
-            from agent_grid.execution_grid import AgentExecution
+            # Create execution config and record
+            from agent_grid.execution_grid import AgentExecution, ExecutionConfig
+            prompt = f"Issue: {issue.title}\n\n{issue.body}"
+            config = ExecutionConfig(
+                repo_url="file:///tmp/test-repo",
+                prompt=prompt,
+                permission_mode="bypassPermissions",
+            )
             execution = AgentExecution(
                 id=uuid4(),
-                issue_id=issue.id,
                 repo_url="file:///tmp/test-repo",
                 status=ExecutionStatus.PENDING,
-                prompt=f"Issue: {issue.title}\n\n{issue.body}",
+                prompt=prompt,
             )
 
             # Run with mocked SDK and patched event bus
             with patch("agent_grid.execution_grid.agent_runner.query", mock_query), \
                  patch("agent_grid.execution_grid.event_publisher.event_bus", test_event_bus):
-                result = await agent_runner.run(execution, execution.prompt)
+                result = await agent_runner.run(execution, config)
 
             # Step 4: Verify results
             if result.status == ExecutionStatus.FAILED:

--- a/tests/test_execution_grid.py
+++ b/tests/test_execution_grid.py
@@ -48,7 +48,6 @@ class TestExecutionEventPublisher:
         # This should not raise
         await publisher.agent_started(
             execution_id=uuid4(),
-            issue_id="123",
             repo_url="https://github.com/test/repo.git",
         )
 


### PR DESCRIPTION
Move prompt generation out of the execution_grid into the coordintaor.  Remove the hard-coded stuff about git branching and GH issues.