### PR TITLE
Add missing env vars to App Runner service

### DIFF
--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -150,6 +150,10 @@ module "apprunner" {
   environment_variables = {
     AGENT_GRID_AWS_REGION         = var.aws_region
     AGENT_GRID_ISSUE_TRACKER_TYPE = "github"
+    AGENT_GRID_TARGET_REPO        = var.target_repo
+    AGENT_GRID_FLY_APP_NAME       = var.fly_app_name
+    AGENT_GRID_FLY_WORKER_IMAGE   = var.fly_worker_image
+    AGENT_GRID_DRY_RUN            = var.dry_run ? "true" : "false"
   }
 
   environment_secrets = merge(
@@ -157,8 +161,12 @@ module "apprunner" {
       AGENT_GRID_DATABASE_URL = "${module.secrets.database_secret_arn}:connection_string::"
     },
     var.github_token != "" ? {
-      AGENT_GRID_GITHUB_TOKEN        = "${module.secrets.github_secret_arn}:token::"
+      AGENT_GRID_GITHUB_TOKEN          = "${module.secrets.github_secret_arn}:token::"
       AGENT_GRID_GITHUB_WEBHOOK_SECRET = "${module.secrets.github_secret_arn}:webhook_secret::"
+    } : {},
+    module.secrets.coordinator_secret_arn != "" ? {
+      AGENT_GRID_FLY_API_TOKEN    = "${module.secrets.coordinator_secret_arn}:fly_api_token::"
+      AGENT_GRID_ANTHROPIC_API_KEY = "${module.secrets.coordinator_secret_arn}:anthropic_api_key::"
     } : {}
   )
 


### PR DESCRIPTION
## Summary
- Added `AGENT_GRID_ANTHROPIC_API_KEY` and `AGENT_GRID_FLY_API_TOKEN` secrets to App Runner (were only on ECS task)
- Added `AGENT_GRID_TARGET_REPO`, `AGENT_GRID_FLY_APP_NAME`, `AGENT_GRID_FLY_WORKER_IMAGE`, `AGENT_GRID_DRY_RUN` env vars to App Runner
- This fixes the webhook classifier failing with "Could not resolve authentication method" error

## Context
The coordinator secrets were correctly wired to the ECS scheduled task but missing from the App Runner service configuration. Since App Runner is the always-on webhook listener, it needs these secrets to classify issues and spawn workers.

Already applied via `tofu apply` — this PR captures the IaC fix.

## Test plan
- [x] `tofu apply` succeeded, App Runner redeployed
- [x] Webhook received, issue classified, Fly Machine spawned for issue #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)