### PR TITLE
Add CI failure auto-fix for agent PRs

### DIFF
--- a/src/agent_grid/config.py
+++ b/src/agent_grid/config.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
     max_tokens_per_run: int = 100000
     max_cost_per_day_usd: float = 50.0
     max_retries_per_issue: int = 2
+    max_ci_fix_retries: int = 2
 
     # Dry-run mode — reads from GitHub but logs all writes to file instead
     dry_run: bool = False

--- a/src/agent_grid/coordinator/prompt_builder.py
+++ b/src/agent_grid/coordinator/prompt_builder.py
@@ -221,4 +221,54 @@ git push -u origin {new_branch}
         )
         return prompt
 
+    elif mode == "fix_ci":
+        pr_number = context.get("pr_number")
+        existing_branch = context.get("existing_branch", branch_name)
+        check_name = context.get("check_name", "")
+        check_output = context.get("check_output", "")
+        check_url = context.get("check_url", "")
+
+        prompt = (
+            base
+            + f"""
+## IMPORTANT: CI check "{check_name}" failed on your PR #{pr_number}
+
+Previous work is on branch: {existing_branch}
+Checkout that branch (don't create a new one):
+```bash
+git checkout {existing_branch}
+git pull origin {existing_branch}
+```
+
+### CI Failure Details
+- Check: {check_name}
+- URL: {check_url}
+
+Output:
+```
+{check_output[:2000]}
+```
+
+### Instructions
+1. Read the CI failure output above carefully
+2. Reproduce the failure locally by running the relevant check
+3. Fix the issue with minimal changes — do not refactor unrelated code
+4. Run the check locally to verify the fix
+5. Push the fix to the same branch:
+```bash
+git push origin {existing_branch}
+```
+
+Do NOT create a new PR. Your commits will be added to the existing PR #{pr_number}.
+Do NOT force push or squash.
+"""
+        )
+        if checkpoint:
+            prompt += f"""
+## Previous Context
+What the previous agent run did:
+- {checkpoint.get("context_summary", "N/A")}
+"""
+        return prompt
+
     return base

--- a/src/agent_grid/execution_grid/public_api.py
+++ b/src/agent_grid/execution_grid/public_api.py
@@ -58,6 +58,7 @@ class EventType(str, Enum):
     NUDGE_REQUESTED = "nudge.requested"
     PR_REVIEW = "pr.review"
     PR_CLOSED = "pr.closed"
+    CHECK_RUN_FAILED = "check_run.failed"
 
 
 class Event(BaseModel):


### PR DESCRIPTION
## Summary
- Detects CI check failures on agent-created PRs via `check_run` webhook
- Automatically spawns a new agent to fix the failing check on the same branch
- Tracks fix attempts per-commit-SHA to avoid duplicate work
- Configurable retry limit (`max_ci_fix_retries`, default 2) — gives up after N attempts

## Changes
- **EventType**: Added `CHECK_RUN_FAILED` event
- **Webhook handler**: New `_handle_check_run_event` — filters for failures on `agent/*` branches
- **Scheduler**: New `_handle_check_run_failed` — deduplicates by SHA, checks retry limit, launches fix agent
- **Management loop**: New `_launch_ci_fix` — fetches issue/checkpoint, builds prompt, claims and launches
- **Prompt builder**: New `fix_ci` mode — instructs agent to checkout existing branch, read CI output, fix and push
- **Config**: New `max_ci_fix_retries` setting
- **Webhook config**: Added `check_run` event to broker-assist webhook (already applied)

## Flow
```
CI fails on agent/123 PR
  → GitHub sends check_run webhook (action=completed, conclusion=failure)
  → Webhook handler publishes CHECK_RUN_FAILED event
  → Scheduler checks SHA dedup + retry limit
  → Management loop spawns Fly Machine with fix_ci prompt
  → Agent checks out branch, reads CI output, fixes, pushes
  → CI re-runs on the same PR
```

## Test plan
- [x] Ruff lint passes
- [ ] CI passes on this PR
- [ ] Create a test issue that triggers a PR with failing CI, observe auto-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)