### PR TITLE
Fix CI fix metadata bug: only update on successful launch

### DIFF
--- a/src/agent_grid/coordinator/scheduler.py
+++ b/src/agent_grid/coordinator/scheduler.py
@@ -318,9 +318,13 @@ class Scheduler:
         from .management_loop import get_management_loop
 
         loop = get_management_loop()
-        await loop._launch_ci_fix(repo, payload)
+        launched = await loop._launch_ci_fix(repo, payload)
 
-        # Update metadata with SHA and increment count
+        if not launched:
+            logger.info(f"Issue #{issue_id}: CI fix agent not launched (active execution or claim failed)")
+            return
+
+        # Only update metadata after successful launch
         updated_metadata = {**metadata, "last_ci_check_sha": head_sha, "ci_fix_count": ci_fix_count + 1}
         await self._db.upsert_issue_state(
             issue_number=int(issue_id),


### PR DESCRIPTION
## Summary
- `_launch_ci_fix` now returns `bool` instead of `None`
- `_handle_check_run_failed` only updates `last_ci_check_sha` and `ci_fix_count` metadata when launch actually succeeds
- Previously, metadata was updated unconditionally — so if launch was blocked by an active execution, the SHA dedup would prevent all future attempts for that commit

## Context
When the CI fix feature was first triggered for issue #1502, the original worker was still running. `_launch_ci_fix` hit the `_has_active_execution` guard and returned without launching, but the scheduler still recorded the SHA and bumped `ci_fix_count`. All subsequent check_run webhooks for the same SHA got silently deduped.

## Test plan
- [ ] After merge + deploy, re-run CI on PR #1551 to trigger a `check_run` webhook
- [ ] Verify a fix agent Fly Machine is spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)