### PR TITLE
Fetch CI logs from Actions API for fix_ci prompt

### DIFF
--- a/src/agent_grid/issue_tracker/webhook_handler.py
+++ b/src/agent_grid/issue_tracker/webhook_handler.py
@@ -285,6 +285,7 @@ async def _handle_check_run_event(data: dict[str, Any]) -> None:
             "check_name": check_run.get("name", ""),
             "check_output": check_output[:3000],
             "check_url": check_run.get("html_url", ""),
+            "job_id": check_run.get("id"),  # Actions job ID for log download
         },
     )
     logger.info(f"CI check '{check_run.get('name')}' failed on {head_branch} — published CHECK_RUN_FAILED")


### PR DESCRIPTION
## Summary
- Add `get_actions_job_logs(repo, job_id)` to GitHubClient — downloads job logs via Actions API
- Pass `job_id` (check_run.id) through the CHECK_RUN_FAILED event payload
- In scheduler, fetch logs before launching CI fix agent when `check_output` is empty
- Returns tail ~3000 chars (where build errors live)

## Problem
GitHub Actions check_run webhooks have empty `output.summary` and `output.text` fields (those are only set by the Check Runs API, not Actions). The fix agent got no error context and spent 20+ minutes ($1.39) blindly trying to reproduce the failure on a 2-CPU machine.

## How it works
1. Webhook handler now includes `check_run.id` as `job_id` in the event
2. Scheduler checks if `check_output` is empty
3. If empty, calls `GET /repos/{repo}/actions/jobs/{job_id}/logs` (follows 302 redirect)
4. Includes the tail of the logs in the payload passed to `_launch_ci_fix`
5. The existing `fix_ci` prompt template already renders `check_output` — no prompt changes needed

## Test plan
- [ ] After merge + deploy, re-trigger CI on PR #1552
- [ ] Check App Runner logs for "fetched N chars of CI logs"
- [ ] Verify worker logs show the agent reading actual error output instead of exploring blindly

🤖 Generated with [Claude Code](https://claude.com/claude-code)