### PR TITLE
Fix ruff lint in public_api admin endpoints

### DIFF
--- a/src/agent_grid/coordinator/public_api.py
+++ b/src/agent_grid/coordinator/public_api.py
@@ -206,8 +206,8 @@ async def cancel_execution(execution_id: UUID) -> dict[str, str]:
 @coordinator_router.get("/issue-state/{issue_number}")
 async def get_issue_state(issue_number: int, repo: str | None = None) -> dict[str, Any]:
     """Get issue state including metadata."""
-    from .database import get_database
     from ..config import settings
+    from .database import get_database
 
     db = get_database()
     state = await db.get_issue_state(issue_number, repo or settings.target_repo)
@@ -219,8 +219,8 @@ async def get_issue_state(issue_number: int, repo: str | None = None) -> dict[st
 @coordinator_router.post("/issue-state/{issue_number}/reset-ci")
 async def reset_ci_fix_count(issue_number: int, repo: str | None = None) -> dict[str, Any]:
     """Reset the CI fix counter for an issue."""
-    from .database import get_database
     from ..config import settings
+    from .database import get_database
 
     db = get_database()
     actual_repo = repo or settings.target_repo


### PR DESCRIPTION
## Summary
- Fix import ordering in the new admin endpoints (get_issue_state, reset_ci_fix_count)
- The parent commits on main already include the callback URL fix and execution ID fix

## Context
This fixes the ruff lint failure that blocked the CI deploy of the previous main commits:
- Fix worker callback URL (coordinator_url instead of fly app URL)
- Fix execution ID mismatch between DB and Fly Machine
- Add admin endpoints for issue state and CI fix counter reset

## Test plan
- [x] `ruff check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)