### PR TITLE
Fix reset-ci endpoint JSON metadata parsing

### DIFF
--- a/src/agent_grid/coordinator/public_api.py
+++ b/src/agent_grid/coordinator/public_api.py
@@ -228,6 +228,10 @@ async def reset_ci_fix_count(issue_number: int, repo: str | None = None) -> dict
     if not state:
         raise HTTPException(status_code=404, detail="Issue state not found")
     metadata = state.get("metadata") or {}
+    if isinstance(metadata, str):
+        import json
+
+        metadata = json.loads(metadata)
     metadata.pop("ci_fix_count", None)
     metadata.pop("last_ci_check_sha", None)
     await db.upsert_issue_state(issue_number=issue_number, repo=actual_repo, metadata=metadata)


### PR DESCRIPTION
## Summary
- Fix `POST /api/issue-state/{issue_number}/reset-ci` endpoint crashing with 500
- The `metadata` field in `issue_state` is stored as a JSON string in PostgreSQL, not a dict
- Added `json.loads()` before modifying the metadata

## Test plan
- [x] `ruff check` passes
- [ ] Call `POST /api/issue-state/1502/reset-ci` after deploy and verify 200 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)