### PR TITLE
Assign issue owner as PR reviewer and comment on PR

### DIFF
--- a/src/agent_grid/coordinator/scheduler.py
+++ b/src/agent_grid/coordinator/scheduler.py
@@ -524,7 +524,7 @@ class Scheduler:
         await self._process_pending_nudges()
 
     async def _assign_and_tag_owner(self, repo: str, issue_id: str, pr_number: int | None = None) -> None:
-        """Assign the issue to its author and tag them for review."""
+        """Assign the issue to its author, request PR review, and comment on the PR."""
         tracker = get_issue_tracker()
         try:
             issue = await tracker.get_issue(repo, issue_id)
@@ -536,13 +536,21 @@ class Scheduler:
             if isinstance(tracker, GitHubClient):
                 await tracker.assign_issue(repo, issue_id, issue.author)
 
+                if pr_number:
+                    await tracker.request_pr_reviewers(repo, pr_number, [issue.author])
+                    await tracker.add_pr_comment(
+                        repo,
+                        pr_number,
+                        f"@{issue.author} — this PR is ready for your review.",
+                    )
+
             pr_ref = f" PR #{pr_number}" if pr_number else ""
             await tracker.add_comment(
                 repo,
                 issue_id,
                 f"@{issue.author} — implementation is ready for your review.{pr_ref}",
             )
-            logger.info(f"Issue #{issue_id}: assigned to @{issue.author}")
+            logger.info(f"Issue #{issue_id}: assigned to @{issue.author}, requested review on PR #{pr_number}")
         except Exception as e:
             logger.warning(f"Failed to assign/tag owner for issue #{issue_id}: {e}")
 

--- a/src/agent_grid/dry_run.py
+++ b/src/agent_grid/dry_run.py
@@ -166,6 +166,12 @@ class DryRunIssueTracker(GitHubClient):
     async def assign_issue(self, repo: str, issue_id: str, assignee: str) -> None:
         self._log.log("assign_issue", repo=repo, issue_id=issue_id, assignee=assignee)
 
+    async def request_pr_reviewers(self, repo: str, pr_number: int, reviewers: list[str]) -> None:
+        self._log.log("request_pr_reviewers", repo=repo, pr_number=pr_number, reviewers=reviewers)
+
+    async def add_pr_comment(self, repo: str, pr_number: int, body: str) -> None:
+        self._log.log("add_pr_comment", repo=repo, pr_number=pr_number, body=body[:500])
+
     async def close(self) -> None:
         await self._real.close()
 

--- a/src/agent_grid/issue_tracker/github_client.py
+++ b/src/agent_grid/issue_tracker/github_client.py
@@ -367,6 +367,28 @@ class GitHubClient(IssueTracker):
         except httpx.HTTPStatusError as e:
             logger.warning(f"Failed to assign issue #{issue_id} to {assignee}: {e}")
 
+    async def request_pr_reviewers(self, repo: str, pr_number: int, reviewers: list[str]) -> None:
+        """Request reviewers on a pull request."""
+        if not reviewers:
+            return
+        try:
+            await self._client.post(
+                f"/repos/{repo}/pulls/{pr_number}/requested_reviewers",
+                json={"reviewers": reviewers},
+            )
+        except httpx.HTTPStatusError as e:
+            logger.warning(f"Failed to request reviewers on PR #{pr_number}: {e}")
+
+    async def add_pr_comment(self, repo: str, pr_number: int, body: str) -> None:
+        """Post a comment on a pull request."""
+        try:
+            await self._client.post(
+                f"/repos/{repo}/issues/{pr_number}/comments",
+                json={"body": body},
+            )
+        except httpx.HTTPStatusError as e:
+            logger.warning(f"Failed to comment on PR #{pr_number}: {e}")
+
     async def close(self) -> None:
         """Close the HTTP client."""
         await self._client.aclose()


### PR DESCRIPTION
## Summary
- Added `request_pr_reviewers()` and `add_pr_comment()` to `GitHubClient`
- When an agent completes and creates a PR, the issue owner is now:
  - Assigned as a reviewer on the PR
  - Tagged in a PR comment asking them to review
- Updated dry-run wrappers for the new methods

## Test plan
- [x] Lint and format pass
- [ ] Merge and verify reviewer assignment on next agent PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)