### PR TITLE
Fix PR reviewer and label for sub-issues

### DIFF
--- a/src/agent_grid/coordinator/management_loop.py
+++ b/src/agent_grid/coordinator/management_loop.py
@@ -313,6 +313,38 @@ class ManagementLoop:
         )
         return True
 
+    async def _resolve_reviewer(self, repo: str, issue) -> str | None:
+        """Resolve the right reviewer for an issue.
+
+        For sub-issues (ag/sub-issue label), look up the parent issue's author
+        since the sub-issue was created by the bot, not a human.
+        Falls back to issue.author if parent lookup fails.
+        """
+        if "ag/sub-issue" not in issue.labels:
+            return None  # Use default (issue.author)
+
+        # Parse parent issue number from title "[Sub #NNN]" or body "Part of #NNN"
+        parent_number = None
+        title_match = re.search(r"\[Sub #(\d+)\]", issue.title)
+        if title_match:
+            parent_number = title_match.group(1)
+        elif issue.body:
+            body_match = re.search(r"Part of #(\d+)", issue.body)
+            if body_match:
+                parent_number = body_match.group(1)
+
+        if not parent_number:
+            return None
+
+        try:
+            parent = await self._tracker.get_issue(repo, parent_number)
+            if parent and parent.author:
+                return parent.author
+        except Exception as e:
+            logger.warning(f"Issue #{issue.number}: failed to resolve parent #{parent_number} author: {e}")
+
+        return None
+
     async def _has_active_execution(self, issue_id: str) -> bool:
         """Check if there's already a running/pending execution for this issue."""
         existing = await self._db.get_execution_for_issue(issue_id)
@@ -329,7 +361,9 @@ class ManagementLoop:
         labels = get_label_manager()
         await labels.transition_to(repo, issue.id, "ag/in-progress")
 
-        prompt = build_prompt(issue, repo, mode="implement")
+        reviewer = await self._resolve_reviewer(repo, issue)
+        context = {"reviewer": reviewer} if reviewer else None
+        prompt = build_prompt(issue, repo, mode="implement", context=context)
         repo_url = f"https://github.com/{repo}.git"
 
         launched = await self._claim_and_launch(
@@ -366,6 +400,9 @@ class ManagementLoop:
                     clarification_comments.append(comment.body)
 
         context = {"clarification_comments": clarification_comments}
+        reviewer = await self._resolve_reviewer(repo, issue)
+        if reviewer:
+            context["reviewer"] = reviewer
         prompt = build_prompt(issue, repo, mode="implement", context=context)
 
         launched = await self._claim_and_launch(
@@ -413,6 +450,10 @@ class ManagementLoop:
             "review_comments": pr_info["review_comments"],
         }
 
+        reviewer = await self._resolve_reviewer(repo, issue)
+        if reviewer:
+            context["reviewer"] = reviewer
+
         prompt = build_prompt(issue, repo, mode="address_review", context=context, checkpoint=checkpoint)
 
         launched = await self._claim_and_launch(
@@ -453,6 +494,10 @@ class ManagementLoop:
             "human_feedback": pr_info["human_feedback"],
             "what_not_to_do": checkpoint.get("context_summary", "") if checkpoint else "",
         }
+
+        reviewer = await self._resolve_reviewer(repo, issue)
+        if reviewer:
+            context["reviewer"] = reviewer
 
         prompt = build_prompt(issue, repo, mode="retry_with_feedback", context=context, checkpoint=checkpoint)
 
@@ -877,6 +922,10 @@ class ManagementLoop:
             context = {}
             if checkpoint:
                 context["what_not_to_do"] = checkpoint.get("context_summary", "")
+
+            reviewer = await self._resolve_reviewer(repo, issue)
+            if reviewer:
+                context["reviewer"] = reviewer
 
             prompt = build_prompt(issue, repo, mode="implement", context=context, checkpoint=checkpoint)
             await labels.transition_to(repo, str(issue.number), "ag/in-progress")

--- a/src/agent_grid/coordinator/prompt_builder.py
+++ b/src/agent_grid/coordinator/prompt_builder.py
@@ -22,7 +22,9 @@ def build_prompt(
     branch_name = f"agent/{issue.number}"
 
     # PR flags for reviewer and label
-    reviewer_flag = f" --reviewer {issue.author}" if issue.author else ""
+    # Use explicit reviewer override (e.g., parent issue owner for sub-issues)
+    reviewer = context.get("reviewer") or issue.author
+    reviewer_flag = f" --reviewer {reviewer}" if reviewer else ""
 
     # Format clarification thread if present
     clarification = ""
@@ -60,7 +62,7 @@ Issue #{issue.number}: {issue.title}
    - Otherwise, manually:
      - Push your branch
      - Create PR with proper fields set:
-       gh pr create --title "..." --body "Closes #{issue.number}" --label "ag/in-progress"{reviewer_flag}
+       gh pr create --title "..." --body "Closes #{issue.number}" --label "ag/review-pending"{reviewer_flag}
    - **EXIT immediately after the PR is created.** Do not continue working.
      Your job is done once the PR exists. CI will run automatically.
 
@@ -294,7 +296,7 @@ git checkout -b {new_branch}
 After implementation, push and create a PR with proper fields:
 ```bash
 git push -u origin {new_branch}
-gh pr create --title "..." --body "Closes #{issue.number}" --label "ag/in-progress"{reviewer_flag}
+gh pr create --title "..." --body "Closes #{issue.number}" --label "ag/review-pending"{reviewer_flag}
 ```
 
 **EXIT immediately after the PR is created.** Your job is done. CI will run automatically.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -452,7 +452,7 @@ class TestPRCreationPrompt:
         from agent_grid.coordinator.prompt_builder import build_prompt
 
         prompt = build_prompt(self._make_issue(), "owner/repo", mode="implement")
-        assert '--label "ag/in-progress"' in prompt
+        assert '--label "ag/review-pending"' in prompt
 
     def test_retry_prompt_includes_reviewer_flag(self):
         """Retry mode gh pr create should also include --reviewer."""
@@ -476,7 +476,7 @@ class TestPRCreationPrompt:
             mode="retry_with_feedback",
             context={"closed_pr_number": 3, "human_feedback": "wrong"},
         )
-        assert '--label "ag/in-progress"' in prompt
+        assert '--label "ag/review-pending"' in prompt
 
     def test_no_cc_author_in_body(self):
         """PR body should not contain 'cc @author' — use --reviewer instead."""
@@ -921,3 +921,70 @@ class TestAutoRetryFailed:
         # Should not attempt to launch
         mock_labels.transition_to.assert_not_called()
         mock_db.get_issue_state.assert_not_called()
+
+
+class TestResolveReviewer:
+    """Tests for _resolve_reviewer — parent issue author lookup for sub-issues."""
+
+    @pytest.mark.asyncio
+    async def test_returns_parent_author_for_sub_issue(self):
+        """Sub-issue should resolve to parent issue's author."""
+        from agent_grid.coordinator.management_loop import ManagementLoop
+        from agent_grid.issue_tracker.public_api import IssueInfo, IssueStatus
+
+        loop = ManagementLoop.__new__(ManagementLoop)
+
+        sub_issue = IssueInfo(
+            id="100",
+            number=100,
+            title="[Sub #50] Do something",
+            body="Part of #50",
+            author="bot-user",
+            labels=["ag/sub-issue"],
+            status=IssueStatus.OPEN,
+            repo_url="https://github.com/owner/repo",
+            html_url="https://github.com/owner/repo/issues/100",
+        )
+
+        parent_issue = IssueInfo(
+            id="50",
+            number=50,
+            title="Parent issue",
+            body="",
+            author="human-user",
+            labels=[],
+            status=IssueStatus.OPEN,
+            repo_url="https://github.com/owner/repo",
+            html_url="https://github.com/owner/repo/issues/50",
+        )
+
+        mock_tracker = AsyncMock()
+        mock_tracker.get_issue = AsyncMock(return_value=parent_issue)
+        loop._tracker = mock_tracker
+
+        reviewer = await loop._resolve_reviewer("owner/repo", sub_issue)
+        assert reviewer == "human-user"
+        mock_tracker.get_issue.assert_called_once_with("owner/repo", "50")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_sub_issue(self):
+        """Non-sub-issue should return None (use default author)."""
+        from agent_grid.coordinator.management_loop import ManagementLoop
+        from agent_grid.issue_tracker.public_api import IssueInfo, IssueStatus
+
+        loop = ManagementLoop.__new__(ManagementLoop)
+
+        regular_issue = IssueInfo(
+            id="100",
+            number=100,
+            title="Regular issue",
+            body="Fix a bug",
+            author="human-user",
+            labels=[],
+            status=IssueStatus.OPEN,
+            repo_url="https://github.com/owner/repo",
+            html_url="https://github.com/owner/repo/issues/100",
+        )
+
+        reviewer = await loop._resolve_reviewer("owner/repo", regular_issue)
+        assert reviewer is None


### PR DESCRIPTION
## Summary
- **Fix sub-issue PR reviewer**: Sub-issues are created by the bot (`mohithg`), so `issue.author` is the bot account. PRs had no reviewer because GitHub ignores `--reviewer` when it matches the PR author. New `_resolve_reviewer()` parses the parent issue number from the title (`[Sub #NNN]`) or body (`Part of #NNN`), fetches the parent, and uses its author as reviewer. Applied to all 5 launch paths.
- **Fix PR label**: Changed from `ag/in-progress` to `ag/review-pending` in prompt — work is done when a PR is created.

## Test plan
- [x] `TestResolveReviewer::test_returns_parent_author_for_sub_issue` — verifies parent author lookup
- [x] `TestResolveReviewer::test_returns_none_for_non_sub_issue` — no-op for regular issues  
- [x] All 150 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)