### PR TITLE
Fix Oz poller: update DB before publishing event

### DIFF
--- a/src/agent_grid/execution_grid/oz_grid.py
+++ b/src/agent_grid/execution_grid/oz_grid.py
@@ -216,6 +216,29 @@ class OzExecutionGrid(ExecutionGrid):
                     except Exception as e:
                         logger.warning(f"Failed to persist cost for {exec_id}: {e}")
 
+                # Update DB directly before publishing event — ensures DB is
+                # consistent even if the async event handler fails or drops the event.
+                try:
+                    from ..coordinator.database import get_database as _get_db
+
+                    db = _get_db()
+                    if run.state == "SUCCEEDED":
+                        await db.update_execution_result(
+                            execution_id=exec_id,
+                            status=ExecutionStatus.COMPLETED,
+                            result=result,
+                            pr_number=pr_number,
+                            branch=branch,
+                        )
+                    else:
+                        await db.update_execution_result(
+                            execution_id=exec_id,
+                            status=ExecutionStatus.FAILED,
+                            result=result or f"Run {run.state.lower()}",
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to update DB for execution {exec_id}: {e}")
+
                 if run.state == "SUCCEEDED":
                     execution = self._executions.get(exec_id)
                     if execution:


### PR DESCRIPTION
## Summary
- The Oz poller removes runs from `_run_map` after publishing to the event bus, but if the async event handler (`_handle_agent_completed`) fails, the event is consumed/dropped and the DB never gets updated — leaving executions permanently stuck as "pending"
- Fix: update DB directly in the poller BEFORE publishing the event, as a belt-and-suspenders approach. The event handler still runs for label transitions and other side effects, but DB consistency no longer depends on it
- This was causing ~10 Oz runs to complete successfully (with PRs) but the coordinator never tracked them

## Test plan
- [ ] Verify existing tests pass (`pytest tests/ -x --ignore=tests/test_real_e2e.py`)
- [ ] Deploy and confirm new Oz runs get DB status updated even if event handler encounters errors
- [ ] Monitor dashboard for stuck "pending" executions

🤖 Generated with [Claude Code](https://claude.com/claude-code)