### PR TITLE
Fix Oz run reliability: PR detection, bot filtering, dedup

### DIFF
--- a/src/agent_grid/coordinator/database.py
+++ b/src/agent_grid/coordinator/database.py
@@ -746,20 +746,24 @@ class Database:
         branch: str | None = None,
         checkpoint: dict | None = None,
     ) -> None:
-        """Update execution with result details."""
+        """Update execution with result details.
+
+        Only overwrites pr_number, branch, and checkpoint when a non-None
+        value is provided — avoids clobbering data written by an earlier call.
+        """
+        values: dict = {
+            "status": status.value,
+            "result": result,
+            "completed_at": func.now(),
+        }
+        if pr_number is not None:
+            values["pr_number"] = pr_number
+        if branch is not None:
+            values["branch"] = branch
+        if checkpoint is not None:
+            values["checkpoint"] = checkpoint
         async with self._session() as session:
-            await session.execute(
-                update(ExecutionModel)
-                .where(ExecutionModel.id == execution_id)
-                .values(
-                    status=status.value,
-                    result=result,
-                    pr_number=pr_number,
-                    branch=branch,
-                    checkpoint=checkpoint,  # SQLAlchemy JSON type handles serialization
-                    completed_at=func.now(),
-                )
-            )
+            await session.execute(update(ExecutionModel).where(ExecutionModel.id == execution_id).values(**values))
             await session.commit()
 
 

--- a/src/agent_grid/coordinator/management_loop.py
+++ b/src/agent_grid/coordinator/management_loop.py
@@ -161,10 +161,21 @@ class ManagementLoop:
 
         # Phase 5: Monitor PRs for review comments
         pr_monitor = get_pr_monitor()
-        prs_needing_work = await pr_monitor.check_prs(repo)
-        for pr_info in prs_needing_work:
-            if pr_info["issue_id"]:
-                await self._launch_review_handler(repo, pr_info)
+        prs_raw = await pr_monitor.check_prs(repo)
+        # Dedup by issue_id — merge review_comments for the same issue
+        seen_pr_issues: dict[str, dict] = {}
+        for pr_info in prs_raw:
+            iid = pr_info.get("issue_id")
+            if not iid:
+                continue
+            if iid in seen_pr_issues:
+                extra = pr_info.get("review_comments", "")
+                if extra and extra not in seen_pr_issues[iid].get("review_comments", ""):
+                    seen_pr_issues[iid]["review_comments"] += "\n\n---\n\n" + extra
+            else:
+                seen_pr_issues[iid] = dict(pr_info)
+        for pr_info in seen_pr_issues.values():
+            await self._launch_review_handler(repo, pr_info)
 
         # Phase 6: Monitor closed PRs with feedback
         closed_prs = await pr_monitor.check_closed_prs(repo)

--- a/src/agent_grid/coordinator/pr_monitor.py
+++ b/src/agent_grid/coordinator/pr_monitor.py
@@ -73,6 +73,7 @@ class PRMonitor:
                 continue
 
             pr_number = pr["number"]
+            pr_author = pr.get("user", {}).get("login", "")
 
             # Fetch review comments
             try:
@@ -93,9 +94,13 @@ class PRMonitor:
                 logger.error(f"Failed to fetch reviews for PR #{pr_number}: {e}")
                 continue
 
-            # Filter for new comments since last check
+            # Filter for new human comments since last check
+            # Skip bot comments and self-comments (agent reviewing its own PR)
             new_reviews = []
             for review in reviews:
+                reviewer = review.get("user", {})
+                if reviewer.get("type") == "Bot" or reviewer.get("login") == pr_author:
+                    continue
                 is_actionable = review.get("state") in ("CHANGES_REQUESTED", "COMMENTED")
                 if is_actionable and review.get("body"):
                     submitted = _normalize_timestamp(review.get("submitted_at", ""))
@@ -104,6 +109,9 @@ class PRMonitor:
 
             new_comments = []
             for comment in pr_comments:
+                commenter = comment.get("user", {})
+                if commenter.get("type") == "Bot" or commenter.get("login") == pr_author:
+                    continue
                 created = _normalize_timestamp(comment.get("created_at", ""))
                 if not last_check or created > _normalize_timestamp(last_check):
                     path = comment.get("path", "")

--- a/src/agent_grid/coordinator/prompt_builder.py
+++ b/src/agent_grid/coordinator/prompt_builder.py
@@ -57,12 +57,8 @@ Issue #{issue.number}: {issue.title}
    - Then EXIT
 7. When done:
    - Push your branch and create a PR that closes the issue.
-   - If the repo has a `/ship` skill (check .claude/skills/), use it:
-     `/ship` with a commit message, PR title, and body that references "Closes #{issue.number}"
-   - Otherwise, manually:
-     - Push your branch
-     - Create PR with proper fields set:
-       gh pr create --title "..." --body "Closes #{issue.number}" --label "ag/review-pending"{reviewer_flag}
+   - Create PR with proper fields set:
+     gh pr create --title "..." --body "Closes #{issue.number}" --label "ag/review-pending"{reviewer_flag}
    - **EXIT immediately after the PR is created.** Do not continue working.
      Your job is done once the PR exists. CI will run automatically.
 

--- a/src/agent_grid/execution_grid/oz_grid.py
+++ b/src/agent_grid/execution_grid/oz_grid.py
@@ -202,6 +202,41 @@ class OzExecutionGrid(ExecutionGrid):
                 # Build result summary
                 result = run.status_message.message if run.status_message else None
 
+                # Fallback PR detection when Oz didn't provide a PR artifact
+                if run.state == "SUCCEEDED" and pr_number is None:
+                    try:
+                        from ..coordinator.database import get_database as _get_db_fb
+                        from ..issue_tracker import get_issue_tracker
+                        from ..issue_tracker.github_client import GitHubClient
+
+                        _tracker = get_issue_tracker()
+                        if isinstance(_tracker, GitHubClient):
+                            _issue_id = await _get_db_fb().get_issue_id_for_execution(exec_id)
+                            if _issue_id:
+                                _exec = self._executions.get(exec_id)
+                                _repo = (
+                                    _exec.repo_url.replace("https://github.com/", "").rstrip(".git")
+                                    if _exec and _exec.repo_url
+                                    else None
+                                )
+                                if _repo:
+                                    for _candidate in (
+                                        f"agent/{_issue_id}",
+                                        f"agent/{_issue_id}-retry",
+                                    ):
+                                        _pr = await _tracker.get_pr_by_branch(_repo, _candidate)
+                                        if _pr:
+                                            pr_number = _pr["number"]
+                                            branch = _candidate
+                                            pr_url = _pr.get("html_url")
+                                            logger.info(
+                                                f"Fallback: found PR #{pr_number} on branch "
+                                                f"{branch} for execution {exec_id}"
+                                            )
+                                            break
+                    except Exception as _e:
+                        logger.warning(f"Fallback PR detection failed for {exec_id}: {_e}")
+
                 # Capture cost from request_usage
                 request_usage = getattr(run, "request_usage", None)
                 if request_usage:

--- a/src/agent_grid/issue_tracker/github_client.py
+++ b/src/agent_grid/issue_tracker/github_client.py
@@ -352,6 +352,24 @@ class GitHubClient(IssueTracker):
         except Exception as e:
             logger.warning(f"Failed to request reviewers on PR #{pr_number}: {e}")
 
+    async def get_pr_by_branch(self, repo: str, branch: str) -> dict | None:
+        """Find an open PR for the given head branch.
+
+        Returns the raw PR dict or None if no PR exists for that branch.
+        """
+        owner = repo.split("/")[0]
+        try:
+            response = await self._client.get(
+                f"/repos/{repo}/pulls",
+                params={"head": f"{owner}:{branch}", "state": "open", "per_page": 1},
+            )
+            response.raise_for_status()
+            prs = response.json()
+            return prs[0] if prs else None
+        except Exception as e:
+            logger.warning(f"Failed to look up PR for branch {branch}: {e}")
+            return None
+
     async def add_pr_comment(self, repo: str, pr_number: int, body: str) -> None:
         """Post a comment on a pull request."""
         try:


### PR DESCRIPTION
## Summary
- **database.py**: `update_execution_result` no longer overwrites `pr_number`/`branch` with `None` — prevents clobbering data written by an earlier call (e.g., poller writes PR info, then event handler overwrites with None)
- **pr_monitor.py**: Filter out bot comments (`user.type == "Bot"`) and agent self-comments (`user.login == pr_author`) to prevent wasted `address_review` launches — was costing ~$57/cycle
- **prompt_builder.py**: Always use `gh pr create` instead of `/ship` skill so Oz can detect PR artifacts reliably
- **oz_grid.py**: Fallback PR detection via GitHub API when Oz doesn't capture the PR artifact — checks `agent/{issue}` and `agent/{issue}-retry` branches
- **github_client.py**: Add `get_pr_by_branch()` method for PR lookup by head ref
- **management_loop.py**: Dedup `prs_needing_work` by `issue_id` to prevent duplicate review handler launches for the same issue

## Test plan
- [x] All 150 tests pass (`pytest tests/ -x --ignore=tests/test_real_e2e.py`)
- [x] `ruff check` and `ruff format --check` clean
- [ ] Deploy and verify: no more wasted address_review runs, PRs tracked correctly in DB
- [ ] Monitor Oz runs — completed runs should now have pr_number in DB even without Oz artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)