### PR TITLE
Fix _handler_mapping type annotation in fly_grid and service

### DIFF
--- a/src/agent_grid/execution_grid/fly_grid.py
+++ b/src/agent_grid/execution_grid/fly_grid.py
@@ -37,7 +37,7 @@ class FlyExecutionGrid(ExecutionGrid):
         self._fly = get_fly_client()
         self._executions: dict[UUID, AgentExecution] = {}
         self._machine_map: dict[UUID, str] = {}  # execution_id -> machine_id
-        self._handler_mapping: dict[int, Callable[[Event], Awaitable[None]]] = {}
+        self._handler_mapping: dict[AgentEventHandler, Callable[[Event], Awaitable[None]]] = {}
 
     async def launch_agent(
         self,

--- a/src/agent_grid/execution_grid/service.py
+++ b/src/agent_grid/execution_grid/service.py
@@ -29,7 +29,7 @@ class ExecutionGridService(ExecutionGrid):
     def __init__(self):
         self._agent_runner = get_agent_runner()
         # Map handler IDs to internal event handlers for cleanup
-        self._handler_mapping: dict[int, Callable[[Event], Awaitable[None]]] = {}
+        self._handler_mapping: dict[AgentEventHandler, Callable[[Event], Awaitable[None]]] = {}
 
     async def launch_agent(
         self,


### PR DESCRIPTION
## Summary

- Fix stale type annotation `dict[int, ...]` → `dict[AgentEventHandler, ...]` in `fly_grid.py` and `service.py`
- PR #77 changed handler mapping keys from `id(handler)` to `handler` but missed updating the type annotations in these two files (`oz_grid.py` was correctly updated)

## Test plan
- [x] All 150 tests pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)