### PR TITLE
Add daily Oz run hard cap (20/day) with dashboard visibility

### DIFF
--- a/src/agent_grid/config.py
+++ b/src/agent_grid/config.py
@@ -57,6 +57,7 @@ class Settings(BaseSettings):
     oz_environment_id: str = ""
     oz_model_id: str = "claude-sonnet-4-5-20250929"
     oz_poll_interval_seconds: int = 30  # How often to poll Oz for run completion
+    max_oz_runs_per_day: int = 20  # Hard cap on Oz runs per day (cost control)
 
     # Fly.io configuration (used when execution_backend="fly")
     fly_api_token: str = ""

--- a/src/agent_grid/coordinator/budget_manager.py
+++ b/src/agent_grid/coordinator/budget_manager.py
@@ -28,6 +28,12 @@ class BudgetManager:
         if len(running) >= self._max_concurrent:
             return False, f"Max concurrent executions ({self._max_concurrent}) reached"
 
+        # Daily Oz run cap (only when using Oz backend)
+        if settings.execution_backend == "oz":
+            oz_today = await self._db.count_oz_runs_today()
+            if oz_today >= settings.max_oz_runs_per_day:
+                return False, f"Daily Oz run limit ({settings.max_oz_runs_per_day}) reached — {oz_today} runs today"
+
         return True, None
 
     async def get_concurrent_count(self) -> int:
@@ -40,11 +46,17 @@ class BudgetManager:
         concurrent = await self.get_concurrent_count()
         usage = await self._db.get_total_budget_usage()
 
+        oz_runs_today = 0
+        if settings.execution_backend == "oz":
+            oz_runs_today = await self._db.count_oz_runs_today()
+
         return {
             "concurrent_executions": concurrent,
             "max_concurrent": self._max_concurrent,
             "tokens_used": usage["tokens_used"],
             "duration_seconds": usage["duration_seconds"],
+            "oz_runs_today": oz_runs_today,
+            "max_oz_runs_per_day": settings.max_oz_runs_per_day,
         }
 
 

--- a/src/agent_grid/coordinator/database.py
+++ b/src/agent_grid/coordinator/database.py
@@ -1,6 +1,6 @@
 """PostgreSQL database access for coordinator using SQLAlchemy 2.0 async ORM."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from sqlalchemy import func, select, text, update
@@ -287,6 +287,20 @@ class Database:
                 "tokens_used": row.tokens,
                 "duration_seconds": row.duration,
             }
+
+    async def count_oz_runs_today(self) -> int:
+        """Count executions launched via Oz (external_run_id set) since midnight UTC."""
+        async with self._session() as session:
+            today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+            result = await session.execute(
+                select(func.count())
+                .select_from(ExecutionModel)
+                .where(
+                    ExecutionModel.external_run_id.isnot(None),
+                    ExecutionModel.created_at >= today_start,
+                )
+            )
+            return result.scalar_one()
 
     # -------------------------------------------------------------------------
     # Issue state operations

--- a/src/agent_grid/dry_run.py
+++ b/src/agent_grid/dry_run.py
@@ -321,6 +321,9 @@ class DryRunDatabase:
     async def get_total_budget_usage(self, **kwargs) -> dict:
         return {"tokens_used": 0, "duration_seconds": 0}
 
+    async def count_oz_runs_today(self) -> int:
+        return 0
+
     # Pipeline events (audit trail)
 
     async def record_pipeline_event(

--- a/src/agent_grid/static/dashboard.html
+++ b/src/agent_grid/static/dashboard.html
@@ -468,10 +468,14 @@ async function loadOverview() {
 
     // Budget
     const b = data.budget || {};
-    const pct = b.max_concurrent ? Math.round((b.concurrent_executions / b.max_concurrent) * 100) : 0;
+    const concPct = b.max_concurrent ? Math.round((b.concurrent_executions / b.max_concurrent) * 100) : 0;
+    const ozPct = b.max_oz_runs_per_day ? Math.round((b.oz_runs_today / b.max_oz_runs_per_day) * 100) : 0;
+    const ozColor = ozPct >= 100 ? '#e74c3c' : ozPct >= 80 ? '#f39c12' : 'var(--accent)';
     document.getElementById('budget-content').innerHTML = `
-      <div><strong>${b.concurrent_executions || 0}</strong> / ${b.max_concurrent || '?'} concurrent executions</div>
-      <div class="budget-bar"><div class="budget-fill" style="width:${pct}%"></div></div>
+      <div><strong>${b.concurrent_executions || 0}</strong> / ${b.max_concurrent || '?'} concurrent</div>
+      <div class="budget-bar"><div class="budget-fill" style="width:${concPct}%"></div></div>
+      <div style="margin-top:12px"><strong>${b.oz_runs_today || 0}</strong> / ${b.max_oz_runs_per_day || '?'} Oz runs today</div>
+      <div class="budget-bar"><div class="budget-fill" style="width:${ozPct}%;background:${ozColor}"></div></div>
       <div class="budget-text">Tokens used: ${(b.tokens_used || 0).toLocaleString()}</div>`;
 
     // Classifications

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -69,6 +69,9 @@ class MockDatabase:
     async def get_total_budget_usage(self, since=None):
         return {"tokens_used": 0, "duration_seconds": 0}
 
+    async def count_oz_runs_today(self):
+        return 0
+
 
 @pytest.fixture
 def temp_dirs():


### PR DESCRIPTION
## Summary
- Adds `max_oz_runs_per_day` config setting (default: 20) as a hard cost control
- `BudgetManager.can_launch_agent()` now checks daily Oz run count — once the limit is hit, scheduler and management loop stop all launches until the next day
- Dashboard budget card shows a second progress bar for daily Oz runs (yellow at 80%, red at 100%)
- No changes needed in management_loop.py or scheduler.py — they already gate on `can_launch_agent()`

## Test plan
- [x] All 150 tests pass
- [x] Ruff clean
- [ ] Deploy and verify dashboard shows both concurrent and daily Oz bars
- [ ] Verify launches stop when daily limit is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)