### PR TITLE
Fix daily Oz cap to count all executions

### DIFF
--- a/src/agent_grid/coordinator/database.py
+++ b/src/agent_grid/coordinator/database.py
@@ -289,16 +289,16 @@ class Database:
             }
 
     async def count_oz_runs_today(self) -> int:
-        """Count executions launched via Oz (external_run_id set) since midnight UTC."""
+        """Count all executions created today (UTC).
+
+        When execution_backend="oz", every execution is an Oz run.
+        Counts all rows (not just external_run_id IS NOT NULL) so that
+        in-flight launches waiting for their Oz run ID are included.
+        """
         async with self._session() as session:
             today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
             result = await session.execute(
-                select(func.count())
-                .select_from(ExecutionModel)
-                .where(
-                    ExecutionModel.external_run_id.isnot(None),
-                    ExecutionModel.created_at >= today_start,
-                )
+                select(func.count()).select_from(ExecutionModel).where(ExecutionModel.created_at >= today_start)
             )
             return result.scalar_one()
 


### PR DESCRIPTION
## Summary
- `count_oz_runs_today()` was filtering on `external_run_id IS NOT NULL`, but `external_run_id` is set asynchronously *after* the Oz API call succeeds
- In-flight launches (between DB claim and Oz API response) were invisible to the daily cap, allowing overcounting
- Fix: count all executions created today — when `execution_backend="oz"`, every execution is an Oz run

## Test plan
- [x] All 150 tests pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)