### PR TITLE
Fix: ag/proactive was blocking scanner from picking up ag/todo issues

### DIFF
--- a/src/agent_grid/coordinator/scanner.py
+++ b/src/agent_grid/coordinator/scanner.py
@@ -28,7 +28,9 @@ HANDLED_LABELS = {
     "ag/failed",
     "ag/skipped",
     "ag/epic",
-    "ag/proactive",
+    # Note: ag/proactive is NOT here — it's a marker label indicating how
+    # the issue was picked up, not a pipeline state. Issues with ag/proactive
+    # + ag/todo should still be scanned.
 }
 
 AG_PREFIX = "ag/"


### PR DESCRIPTION
ag/proactive is a marker label, not a pipeline state. Was in HANDLED_LABELS causing scanner to skip issues with both ag/todo and ag/proactive.